### PR TITLE
Add error message when callable is string and cannot be instantiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.2 under development
 
-- Enh #32: Use more detailed exception messages in `ListenerConfigurationChecker` (vjik)
+- Enh #32: Use more detailed exception messages in `ListenerConfigurationChecker` (vjik, thenotsoft)
 
 ## 1.0.1 August 30, 2021
 

--- a/src/ListenerConfigurationChecker.php
+++ b/src/ListenerConfigurationChecker.php
@@ -81,8 +81,15 @@ final class ListenerConfigurationChecker
     private function createNotCallableMessage($definition): string
     {
         if (is_string($definition) && class_exists($definition)) {
+            if (!method_exists($definition, '__invoke')) {
+                return sprintf(
+                    '"__invoke" method is not defined in "%s" class.',
+                    $definition
+                );
+            }
+
             return sprintf(
-                'Could not instantiate "%s" or "__invoke" is not defined in this class.',
+                'Failed to instantiate "%s" class.',
                 $definition
             );
         }
@@ -106,6 +113,7 @@ final class ListenerConfigurationChecker
                 );
             }
         }
+
         return 'Listener must be a callable. Got ' . $this->listenerDump($definition) . '.';
     }
 

--- a/src/ListenerConfigurationChecker.php
+++ b/src/ListenerConfigurationChecker.php
@@ -80,6 +80,13 @@ final class ListenerConfigurationChecker
      */
     private function createNotCallableMessage($definition): string
     {
+        if (is_string($definition) && class_exists($definition)) {
+            return sprintf(
+                'Could not instantiate "%s" or "__invoke" is not defined in this class.',
+                $definition
+            );
+        }
+
         if (is_array($definition)
             && array_keys($definition) === [0, 1]
             && is_string($definition[1])

--- a/tests/ListenerConfigurationCheckerTest.php
+++ b/tests/ListenerConfigurationCheckerTest.php
@@ -12,6 +12,7 @@ use Yiisoft\Yii\Event\InvalidEventConfigurationFormatException;
 use Yiisoft\Yii\Event\InvalidListenerConfigurationException;
 use Yiisoft\Yii\Event\ListenerConfigurationChecker;
 use Yiisoft\Yii\Event\CallableFactory;
+use Yiisoft\Yii\Event\Tests\Mock\BadInvokableClass;
 use Yiisoft\Yii\Event\Tests\Mock\Event;
 use Yiisoft\Yii\Event\Tests\Mock\ExceptionalContainer;
 use Yiisoft\Yii\Event\Tests\Mock\HandlerInvokable;
@@ -63,9 +64,13 @@ class ListenerConfigurationCheckerTest extends TestCase
                 ['string', 'handle'],
                 'Listener must be a callable. Got array',
             ],
-            'string class' => [
+            'string class without invoke' => [
                 TestClass::class,
-                'Could not instantiate "' . TestClass::class . '" or "__invoke" is not defined in this class.',
+                '"__invoke" method is not defined in "' . TestClass::class . '" class.',
+            ],
+            'string class' => [
+                BadInvokableClass::class,
+                'Failed to instantiate "' . BadInvokableClass::class . '" class.',
             ],
         ];
     }

--- a/tests/ListenerConfigurationCheckerTest.php
+++ b/tests/ListenerConfigurationCheckerTest.php
@@ -63,6 +63,10 @@ class ListenerConfigurationCheckerTest extends TestCase
                 ['string', 'handle'],
                 'Listener must be a callable. Got array',
             ],
+            'string class' => [
+                TestClass::class,
+                'Could not instantiate "' . TestClass::class . '" or "__invoke" is not defined in this class.',
+            ],
         ];
     }
 

--- a/tests/Mock/BadInvokableClass.php
+++ b/tests/Mock/BadInvokableClass.php
@@ -8,7 +8,6 @@ final class BadInvokableClass
 {
     public function __construct(NotExistClass $notExistClass)
     {
-
     }
 
     public function __invoke()

--- a/tests/Mock/BadInvokableClass.php
+++ b/tests/Mock/BadInvokableClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Event\Tests\Mock;
+
+final class BadInvokableClass
+{
+    public function __construct(NotExistClass $notExistClass)
+    {
+
+    }
+
+    public function __invoke()
+    {
+        // do nothing, just for instantiation checks
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |
