### PR TITLE
Separate chain calls

### DIFF
--- a/tests/CallableFactoryTest.php
+++ b/tests/CallableFactoryTest.php
@@ -33,7 +33,9 @@ class CallableFactoryTest extends TestCase
     public function testArray($definition): void
     {
         self::assertIsArray(
-            $this->createFactory()->create($definition),
+            $this
+                ->createFactory()
+                ->create($definition),
         );
     }
 
@@ -52,7 +54,9 @@ class CallableFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             HandlerInvokable::class,
-            $this->createFactory()->create($definition),
+            $this
+                ->createFactory()
+                ->create($definition),
         );
     }
 
@@ -74,7 +78,9 @@ class CallableFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             Closure::class,
-            $this->createFactory()->create($definition),
+            $this
+                ->createFactory()
+                ->create($definition),
         );
     }
 
@@ -100,7 +106,9 @@ class CallableFactoryTest extends TestCase
     public function testException($definition): void
     {
         $this->expectException(InvalidListenerConfigurationException::class);
-        $this->createFactory()->create($definition);
+        $this
+            ->createFactory()
+            ->create($definition);
     }
 
     private function createFactory(?ContainerInterface $container = null): CallableFactory

--- a/tests/EventConfiguratorTest.php
+++ b/tests/EventConfiguratorTest.php
@@ -55,7 +55,9 @@ final class EventConfiguratorTest extends TestCase
             $listener($event);
         }
 
-        $this->assertCount(3, $this->container->get(Event::class)->registered());
+        $this->assertCount(3, $this->container
+            ->get(Event::class)
+            ->registered());
     }
 
     public function testAddEventListenerInjection(): void

--- a/tests/ListenerConfigurationCheckerTest.php
+++ b/tests/ListenerConfigurationCheckerTest.php
@@ -84,7 +84,9 @@ class ListenerConfigurationCheckerTest extends TestCase
         $this->expectExceptionMessage($message);
         $this->expectExceptionCode(0);
 
-        $this->createChecker()->check([Event::class => [$callable]]);
+        $this
+            ->createChecker()
+            ->check([Event::class => [$callable]]);
     }
 
     public function goodCallableProvider(): array
@@ -123,7 +125,9 @@ class ListenerConfigurationCheckerTest extends TestCase
         $this->expectExceptionCode(0);
 
         $callable = [Event::class, 'register'];
-        $this->createChecker(new ExceptionalContainer())->check([Event::class => [$callable]]);
+        $this
+            ->createChecker(new ExceptionalContainer())
+            ->check([Event::class => [$callable]]);
     }
 
     public function testListenersNotIterable(): void
@@ -132,7 +136,9 @@ class ListenerConfigurationCheckerTest extends TestCase
         $this->expectExceptionMessage(sprintf('Event listeners for %s must be an iterable, stdClass given.', Event::class));
         $this->expectExceptionCode(0);
 
-        $this->createChecker()->check([Event::class => new StdClass()]);
+        $this
+            ->createChecker()
+            ->check([Event::class => new StdClass()]);
     }
 
     public function testListenersIncorrectFormat(): void
@@ -141,7 +147,9 @@ class ListenerConfigurationCheckerTest extends TestCase
         $this->expectExceptionMessage('Incorrect event listener format. Format with event name must be used. Got 1.');
         $this->expectExceptionCode(0);
 
-        $this->createChecker()->check([1 => [Event::class, 'register']]);
+        $this
+            ->createChecker()
+            ->check([1 => [Event::class, 'register']]);
     }
 
     private function createChecker(?ContainerInterface $container = null): ListenerConfigurationChecker


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Readability fix  | according to https://github.com/yiisoft/docs/issues/155, chain calls must be put on separate lines.